### PR TITLE
Bugfix/add delivery or not

### DIFF
--- a/src/api/database.json
+++ b/src/api/database.json
@@ -119,6 +119,13 @@
       "email": "mary.j@example.com",
       "address": "456 Oak St",
       "phone": "555-6789"
+    },
+    {
+      "name": "David Clark",
+      "email": "david.clark@example.com",
+      "address": "321 Maple Ave",
+      "phone": "555-9876",
+      "id": 3
     }
   ],
   "orders": [
@@ -137,6 +144,14 @@
       "customerId": 2,
       "tip": 3,
       "isDelivery": false
+    },
+    {
+      "dateTime": "2025-01-24T17:18:10.544Z",
+      "status": "Pending",
+      "tip": 0,
+      "isDelivery": true,
+      "customerId": 3,
+      "id": 3
     }
   ],
   "pizzas": [

--- a/src/components/NavBar/NavBar.jsx
+++ b/src/components/NavBar/NavBar.jsx
@@ -17,7 +17,7 @@ export const NavBar = () => {
                 <Link className="navbar-link">Employee List</Link>
             </li>
             <li>
-                <Link className="navbar-link">Sales Report</Link>
+                <Link to="/salesReport" className="navbar-link">Sales Report</Link>
             </li>
 
             {localStorage.getItem("employee_user") ? (

--- a/src/components/NewOrder/NewOrder.jsx
+++ b/src/components/NewOrder/NewOrder.jsx
@@ -9,6 +9,7 @@ export const NewOrder = () => {
     const [customerEmail, setCustomerEmail] = useState("")
     const [customerAddress, setCustomerAddress] = useState("")
     const [customerPhone, setCustomerPhone] = useState("")
+    const [isDelivery, setIsDelivery] = useState(false)
 
     const navigate = useNavigate()
 
@@ -30,10 +31,10 @@ export const NewOrder = () => {
                         dateTime: new Date(),
                         status: "Pending",
                         tip: 0,
-                        isDelivery: false,
+                        isDelivery: isDelivery,
                         customerId: data[0].id
                     }
-                 return createNewOrder(newOrderObj)
+                    return createNewOrder(newOrderObj)
                 })
                 .then((newOrderData) => {
                     console.log(newOrderData)
@@ -52,8 +53,8 @@ export const NewOrder = () => {
             <fieldset className="customer-info">
                 <div >
                     <label>Full Name: </label>
-                    <input 
-                        type="text" 
+                    <input
+                        type="text"
                         name="name"
                         value={customerName}
                         onChange={(event) => setCustomerName(event.target.value)}
@@ -63,7 +64,7 @@ export const NewOrder = () => {
             <fieldset className="customer-info">
                 <div >
                     <label>Email: </label>
-                    <input 
+                    <input
                         type="text"
                         name="email"
                         value={customerEmail}
@@ -74,7 +75,7 @@ export const NewOrder = () => {
             <fieldset className="customer-info">
                 <div >
                     <label>Address: </label>
-                    <input 
+                    <input
                         type="text"
                         name="address"
                         value={customerAddress}
@@ -85,12 +86,22 @@ export const NewOrder = () => {
             <fieldset className="customer-info">
                 <div >
                     <label>Phone Number: </label>
-                    <input 
+                    <input
                         type="text"
                         name="phone"
                         value={customerPhone}
                         onChange={(event) => setCustomerPhone(event.target.value)}
                         required />
+                </div>
+            </fieldset>
+            <fieldset className="customer-info">
+                <div>
+                    <label>
+                        <input type="radio" name="orderType" checked={!isDelivery} onChange={() => setIsDelivery(false)} />Dine In
+                    </label>
+                    <label>
+                        <input type="radio" name="orderType" checked={isDelivery} onChange={() => setIsDelivery(true)} />Delivery
+                    </label>
                 </div>
             </fieldset>
             <button type="submit" onClick={handleSaveOrder} className="btn">Save Order</button>

--- a/src/components/SalesReport/SalesReport.css
+++ b/src/components/SalesReport/SalesReport.css
@@ -1,0 +1,7 @@
+.report-container {
+    justify-items: center;
+}
+
+.report-container > h2 {
+    text-shadow: 2px 2px lightblue;
+}

--- a/src/components/SalesReport/SalesReport.jsx
+++ b/src/components/SalesReport/SalesReport.jsx
@@ -1,0 +1,11 @@
+import "./SalesReport.css"
+
+export const SalesReport = () => {
+
+
+    return (
+        <section className="report-container">
+            <h2>Sales Report</h2>
+        </section>
+    )
+}

--- a/src/views/ApplicationViews.jsx
+++ b/src/views/ApplicationViews.jsx
@@ -4,6 +4,7 @@ import { NewOrder } from "../components/NewOrder/NewOrder";
 import { OrderDetails } from "../components/OrderDetails/OrderDetails";
 import { OrderList } from "../components/OrderList/OrderList";
 import { EmployeeDetails } from "../components/Employees/EmployeeDetails";
+import { SalesReport } from "../components/SalesReport/SalesReport";
 
 export const ApplicationViews = () => {
     return (
@@ -28,6 +29,7 @@ export const ApplicationViews = () => {
                 <Route path="employee">
                     <Route path=":employeeId" element={<EmployeeDetails />} />
                 </Route>
+                <Route path="salesReport" element={<SalesReport />} />
             </Route>
         </Routes>
     );


### PR DESCRIPTION
What?
Added radio buttons to create new order form, so that the employee taking the order can select if the order is going to be for delivery or dine in.

Why?
Employees need to know if an order is delivery or dine in so they can assign a delivery driver or not.

How?
In NewOrder.jsx I added state that tracks the status of isDelivery that is set to default as false. Then I added radio buttons that change the state when selected to delivery (true) or dine in (false).

Testing?
In New Order page view, there should be radio buttons displaying under the customer details, default select is Dine In, and when Save Order is clicked, the radio button selection should be stored in the isDelivery property on the order object.